### PR TITLE
Add knowledge base CRUD and document management

### DIFF
--- a/database.js
+++ b/database.js
@@ -442,6 +442,36 @@ async function initializeDatabase() {
       CREATE INDEX IF NOT EXISTS idx_ai_usage_user_created ON ai_usage_events(user_id, created_at DESC);
     `);
 
+    console.log('AI Academy: knowledge bases...');
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS knowledge_bases (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        name VARCHAR(255) NOT NULL,
+        description TEXT,
+        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS knowledge_documents (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        knowledge_base_id UUID NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+        user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        original_name VARCHAR(500) NOT NULL,
+        stored_name VARCHAR(500) NOT NULL,
+        mime_type VARCHAR(255) NOT NULL,
+        size_bytes BIGINT DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_kb_user_created ON knowledge_bases(user_id, created_at DESC);
+    `);
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_kd_kb_created ON knowledge_documents(knowledge_base_id, created_at DESC);
+    `);
+
     await seedAcademyCatalog(client);
     await bootstrapAdminEmail(client);
     await mergeExistingUsersAiAllowedModels(client);
@@ -1050,6 +1080,131 @@ async function getLessonProgressForUser(userId) {
   }
 }
 
+async function createKnowledgeBase(userId, { name, description = null }) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `INSERT INTO knowledge_bases (user_id, name, description)
+       VALUES ($1, $2, $3)
+       RETURNING *`,
+      [userId, name, description]
+    );
+    return r.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function listKnowledgeBases(userId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT kb.*,
+              COALESCE(COUNT(kd.id), 0)::int AS documents_count
+       FROM knowledge_bases kb
+       LEFT JOIN knowledge_documents kd ON kd.knowledge_base_id = kb.id
+       WHERE kb.user_id = $1
+       GROUP BY kb.id
+       ORDER BY kb.created_at DESC`,
+      [userId]
+    );
+    return r.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function getKnowledgeBaseForUser(userId, knowledgeBaseId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT * FROM knowledge_bases WHERE id = $1 AND user_id = $2`,
+      [knowledgeBaseId, userId]
+    );
+    return r.rows[0] || null;
+  } finally {
+    client.release();
+  }
+}
+
+async function deleteKnowledgeBase(userId, knowledgeBaseId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `DELETE FROM knowledge_bases WHERE id = $1 AND user_id = $2 RETURNING id`,
+      [knowledgeBaseId, userId]
+    );
+    return !!r.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function addKnowledgeDocument(userId, knowledgeBaseId, fileMeta) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `INSERT INTO knowledge_documents
+        (knowledge_base_id, user_id, original_name, stored_name, mime_type, size_bytes)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [
+        knowledgeBaseId,
+        userId,
+        fileMeta.name,
+        fileMeta.stored,
+        fileMeta.mime,
+        fileMeta.sizeBytes
+      ]
+    );
+    return r.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function listKnowledgeDocuments(userId, knowledgeBaseId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT *
+       FROM knowledge_documents
+       WHERE user_id = $1 AND knowledge_base_id = $2
+       ORDER BY created_at DESC`,
+      [userId, knowledgeBaseId]
+    );
+    return r.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function getKnowledgeDocumentForUser(userId, documentId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT * FROM knowledge_documents WHERE id = $1 AND user_id = $2`,
+      [documentId, userId]
+    );
+    return r.rows[0] || null;
+  } finally {
+    client.release();
+  }
+}
+
+async function deleteKnowledgeDocument(userId, documentId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `DELETE FROM knowledge_documents WHERE id = $1 AND user_id = $2 RETURNING id`,
+      [documentId, userId]
+    );
+    return !!r.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
 async function listUsersForAdmin(limit = 100, offset = 0) {
   const client = await pool.connect();
   try {
@@ -1207,5 +1362,13 @@ module.exports = {
   adminListAllConversations,
   adminGetConversation,
   adminExportUsage,
-  adminSumUsageByUser
+  adminSumUsageByUser,
+  createKnowledgeBase,
+  listKnowledgeBases,
+  getKnowledgeBaseForUser,
+  deleteKnowledgeBase,
+  addKnowledgeDocument,
+  listKnowledgeDocuments,
+  getKnowledgeDocumentForUser,
+  deleteKnowledgeDocument
 };

--- a/database.js
+++ b/database.js
@@ -1140,6 +1140,24 @@ async function deleteKnowledgeBase(userId, knowledgeBaseId) {
   }
 }
 
+async function updateKnowledgeBase(userId, knowledgeBaseId, { name, description }) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `UPDATE knowledge_bases
+       SET name = COALESCE($3, name),
+           description = COALESCE($4, description),
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1 AND user_id = $2
+       RETURNING *`,
+      [knowledgeBaseId, userId, name ?? null, description ?? null]
+    );
+    return r.rows[0] || null;
+  } finally {
+    client.release();
+  }
+}
+
 async function addKnowledgeDocument(userId, knowledgeBaseId, fileMeta) {
   const client = await pool.connect();
   try {
@@ -1172,6 +1190,25 @@ async function listKnowledgeDocuments(userId, knowledgeBaseId) {
        WHERE user_id = $1 AND knowledge_base_id = $2
        ORDER BY created_at DESC`,
       [userId, knowledgeBaseId]
+    );
+    return r.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function searchKnowledgeDocuments(userId, knowledgeBaseId, queryText) {
+  const client = await pool.connect();
+  try {
+    const q = `%${String(queryText || '').trim()}%`;
+    const r = await client.query(
+      `SELECT *
+       FROM knowledge_documents
+       WHERE user_id = $1
+         AND knowledge_base_id = $2
+         AND (original_name ILIKE $3 OR mime_type ILIKE $3)
+       ORDER BY created_at DESC`,
+      [userId, knowledgeBaseId, q]
     );
     return r.rows;
   } finally {
@@ -1366,9 +1403,11 @@ module.exports = {
   createKnowledgeBase,
   listKnowledgeBases,
   getKnowledgeBaseForUser,
+  updateKnowledgeBase,
   deleteKnowledgeBase,
   addKnowledgeDocument,
   listKnowledgeDocuments,
+  searchKnowledgeDocuments,
   getKnowledgeDocumentForUser,
   deleteKnowledgeDocument
 };

--- a/public/academy.html
+++ b/public/academy.html
@@ -47,6 +47,16 @@
           <h3 class="text-xs uppercase tracking-wide text-slate-500 mb-2">Курсы</h3>
           <div id="courseTree" class="space-y-2 text-sm"></div>
         </div>
+        <div>
+          <h3 class="text-xs uppercase tracking-wide text-slate-500 mb-2">База знаний</h3>
+          <div class="space-y-2">
+            <div class="flex gap-1">
+              <input id="kbNameInput" type="text" placeholder="Название базы" class="flex-1 bg-slate-950 border border-slate-700 rounded px-2 py-1 text-xs" />
+              <button type="button" id="createKbBtn" class="bg-slate-800 hover:bg-slate-700 rounded px-2 py-1 text-xs">Создать</button>
+            </div>
+            <ul id="knowledgeBaseList" class="space-y-1 text-xs"></ul>
+          </div>
+        </div>
       </div>
       <div class="p-3 border-t border-slate-800 text-xs text-slate-500">
         <span id="userEmail"></span>

--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -235,7 +235,10 @@ const state = {
   usage: null,
   streaming: false,
   selectedModel: null,
-  lastFailedPayload: null
+  lastFailedPayload: null,
+  knowledgeBases: [],
+  activeKnowledgeBaseId: null,
+  knowledgeDocuments: []
 };
 
 function showGate() {
@@ -275,9 +278,11 @@ async function init() {
     state.catalog = await api('/api/academy/catalog');
     state.usage = await api('/api/academy/usage');
     state.conversations = (await api('/api/academy/conversations')).conversations;
+    state.knowledgeBases = (await api('/api/academy/knowledge-bases')).knowledgeBases || [];
     renderUsage();
     renderCourseTree();
     renderConversationList();
+    renderKnowledgeBases();
     populateModels();
     updateModelHint();
     showApp();
@@ -738,6 +743,8 @@ function wireUi() {
     document.getElementById('assignmentBlock').classList.add('hidden');
   });
 
+  document.getElementById('createKbBtn')?.addEventListener('click', createKnowledgeBaseHandler);
+
   document.getElementById('sendBtn').addEventListener('click', sendHandler);
   document.getElementById('imageGenBtn').addEventListener('click', imageGenHandler);
 
@@ -805,6 +812,159 @@ function wireUi() {
     state.catalog = await api('/api/academy/catalog');
     renderCourseTree();
   });
+}
+
+function formatBytes(bytes) {
+  const b = Number(bytes) || 0;
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${Math.round(b / 1024)} KB`;
+  return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function renderKnowledgeBases() {
+  const ul = document.getElementById('knowledgeBaseList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  if (!state.knowledgeBases.length) {
+    const li = document.createElement('li');
+    li.className = 'text-slate-500';
+    li.textContent = 'Нет баз знаний';
+    ul.appendChild(li);
+    return;
+  }
+  for (const kb of state.knowledgeBases) {
+    const li = document.createElement('li');
+    li.className = 'border border-slate-800 rounded p-2 bg-slate-900/60';
+    const isActive = state.activeKnowledgeBaseId === kb.id;
+    li.innerHTML = `
+      <div class="flex items-center gap-1">
+        <button type="button" data-open-kb="${kb.id}" class="flex-1 text-left ${isActive ? 'text-indigo-300' : 'text-slate-200'} truncate">${escapeHtml(kb.name)}</button>
+        <span class="text-[10px] text-slate-500">${kb.documents_count || 0}</span>
+        <button type="button" data-del-kb="${kb.id}" class="text-red-400 hover:text-red-300 px-1">×</button>
+      </div>
+      <div id="kb-docs-${kb.id}" class="${isActive ? '' : 'hidden'} mt-2 space-y-1"></div>
+      <div id="kb-actions-${kb.id}" class="${isActive ? '' : 'hidden'} mt-2 space-y-1">
+        <input type="file" data-upload-kb="${kb.id}" class="text-[10px] text-slate-400 w-full" multiple />
+      </div>
+    `;
+    ul.appendChild(li);
+  }
+  ul.querySelectorAll('[data-open-kb]').forEach((btn) => {
+    btn.addEventListener('click', () => openKnowledgeBase(btn.getAttribute('data-open-kb')));
+  });
+  ul.querySelectorAll('[data-del-kb]').forEach((btn) => {
+    btn.addEventListener('click', () => deleteKnowledgeBaseHandler(btn.getAttribute('data-del-kb')));
+  });
+  ul.querySelectorAll('[data-upload-kb]').forEach((input) => {
+    input.addEventListener('change', () => uploadDocumentsHandler(input.getAttribute('data-upload-kb'), input));
+  });
+  if (state.activeKnowledgeBaseId) {
+    renderKnowledgeDocuments(state.activeKnowledgeBaseId);
+  }
+}
+
+function renderKnowledgeDocuments(kbId) {
+  const box = document.getElementById(`kb-docs-${kbId}`);
+  if (!box) return;
+  box.innerHTML = '';
+  if (!state.knowledgeDocuments.length) {
+    box.innerHTML = '<div class="text-[10px] text-slate-500">Документов пока нет</div>';
+    return;
+  }
+  for (const d of state.knowledgeDocuments) {
+    const row = document.createElement('div');
+    row.className = 'flex items-center gap-1 text-[10px] text-slate-400';
+    row.innerHTML = `
+      <span class="flex-1 truncate" title="${escapeHtml(d.original_name)}">${escapeHtml(d.original_name)}</span>
+      <span class="text-slate-500">${formatBytes(d.size_bytes)}</span>
+      <button type="button" data-del-doc="${d.id}" class="text-red-400 hover:text-red-300 px-1">×</button>
+    `;
+    box.appendChild(row);
+  }
+  box.querySelectorAll('[data-del-doc]').forEach((btn) => {
+    btn.addEventListener('click', () => deleteDocumentHandler(btn.getAttribute('data-del-doc')));
+  });
+}
+
+async function createKnowledgeBaseHandler() {
+  const input = document.getElementById('kbNameInput');
+  const name = input?.value?.trim();
+  if (!name) return;
+  try {
+    await api('/api/academy/knowledge-bases', {
+      method: 'POST',
+      body: JSON.stringify({ name })
+    });
+    input.value = '';
+    state.knowledgeBases = (await api('/api/academy/knowledge-bases')).knowledgeBases || [];
+    renderKnowledgeBases();
+  } catch (e) {
+    alert(e.message || 'Не удалось создать базу знаний');
+  }
+}
+
+async function openKnowledgeBase(kbId) {
+  state.activeKnowledgeBaseId = kbId;
+  try {
+    const docs = await api(`/api/academy/knowledge-bases/${kbId}/documents`);
+    state.knowledgeDocuments = docs.documents || [];
+    renderKnowledgeBases();
+  } catch (e) {
+    alert(e.message || 'Не удалось загрузить документы');
+  }
+}
+
+async function deleteKnowledgeBaseHandler(kbId) {
+  if (!confirm('Удалить базу знаний и все документы?')) return;
+  try {
+    await api(`/api/academy/knowledge-bases/${kbId}`, { method: 'DELETE' });
+    state.knowledgeBases = (await api('/api/academy/knowledge-bases')).knowledgeBases || [];
+    if (state.activeKnowledgeBaseId === kbId) {
+      state.activeKnowledgeBaseId = null;
+      state.knowledgeDocuments = [];
+    }
+    renderKnowledgeBases();
+  } catch (e) {
+    alert(e.message || 'Не удалось удалить базу знаний');
+  }
+}
+
+async function uploadDocumentsHandler(kbId, inputEl) {
+  if (!inputEl?.files?.length) return;
+  const fd = new FormData();
+  for (let i = 0; i < inputEl.files.length; i += 1) {
+    fd.append('files', inputEl.files[i]);
+  }
+  try {
+    const token = getToken();
+    const res = await fetch(`${apiBase}/api/academy/knowledge-bases/${kbId}/documents`, {
+      method: 'POST',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      body: fd
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(body.error || res.statusText);
+    inputEl.value = '';
+    await openKnowledgeBase(kbId);
+    state.knowledgeBases = (await api('/api/academy/knowledge-bases')).knowledgeBases || [];
+    renderKnowledgeBases();
+  } catch (e) {
+    alert(e.message || 'Не удалось загрузить документы');
+  }
+}
+
+async function deleteDocumentHandler(documentId) {
+  if (!confirm('Удалить документ?')) return;
+  try {
+    await api(`/api/academy/knowledge-documents/${documentId}`, { method: 'DELETE' });
+    if (state.activeKnowledgeBaseId) {
+      await openKnowledgeBase(state.activeKnowledgeBaseId);
+    }
+    state.knowledgeBases = (await api('/api/academy/knowledge-bases')).knowledgeBases || [];
+    renderKnowledgeBases();
+  } catch (e) {
+    alert(e.message || 'Не удалось удалить документ');
+  }
 }
 
 async function sendHandler() {

--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -844,6 +844,11 @@ function renderKnowledgeBases() {
       </div>
       <div id="kb-docs-${kb.id}" class="${isActive ? '' : 'hidden'} mt-2 space-y-1"></div>
       <div id="kb-actions-${kb.id}" class="${isActive ? '' : 'hidden'} mt-2 space-y-1">
+        <div class="flex gap-1">
+          <input type="text" data-rename-kb="${kb.id}" value="${escapeHtml(kb.name)}" class="flex-1 bg-slate-950 border border-slate-700 rounded px-1 py-0.5 text-[10px]" />
+          <button type="button" data-save-kb="${kb.id}" class="text-[10px] px-1.5 rounded bg-slate-800 hover:bg-slate-700">OK</button>
+        </div>
+        <input type="text" data-search-kb="${kb.id}" placeholder="Поиск документов..." class="w-full bg-slate-950 border border-slate-700 rounded px-2 py-1 text-[10px]" />
         <input type="file" data-upload-kb="${kb.id}" class="text-[10px] text-slate-400 w-full" multiple />
       </div>
     `;
@@ -857,6 +862,12 @@ function renderKnowledgeBases() {
   });
   ul.querySelectorAll('[data-upload-kb]').forEach((input) => {
     input.addEventListener('change', () => uploadDocumentsHandler(input.getAttribute('data-upload-kb'), input));
+  });
+  ul.querySelectorAll('[data-save-kb]').forEach((btn) => {
+    btn.addEventListener('click', () => renameKnowledgeBaseHandler(btn.getAttribute('data-save-kb')));
+  });
+  ul.querySelectorAll('[data-search-kb]').forEach((input) => {
+    input.addEventListener('input', () => searchKnowledgeDocumentsHandler(input.getAttribute('data-search-kb'), input.value));
   });
   if (state.activeKnowledgeBaseId) {
     renderKnowledgeDocuments(state.activeKnowledgeBaseId);
@@ -877,10 +888,14 @@ function renderKnowledgeDocuments(kbId) {
     row.innerHTML = `
       <span class="flex-1 truncate" title="${escapeHtml(d.original_name)}">${escapeHtml(d.original_name)}</span>
       <span class="text-slate-500">${formatBytes(d.size_bytes)}</span>
+      <button type="button" data-download-doc="${d.id}" class="text-indigo-400 hover:text-indigo-300 px-1">↓</button>
       <button type="button" data-del-doc="${d.id}" class="text-red-400 hover:text-red-300 px-1">×</button>
     `;
     box.appendChild(row);
   }
+  box.querySelectorAll('[data-download-doc]').forEach((btn) => {
+    btn.addEventListener('click', () => downloadDocumentHandler(btn.getAttribute('data-download-doc')));
+  });
   box.querySelectorAll('[data-del-doc]').forEach((btn) => {
     btn.addEventListener('click', () => deleteDocumentHandler(btn.getAttribute('data-del-doc')));
   });
@@ -950,6 +965,60 @@ async function uploadDocumentsHandler(kbId, inputEl) {
     renderKnowledgeBases();
   } catch (e) {
     alert(e.message || 'Не удалось загрузить документы');
+  }
+}
+
+async function renameKnowledgeBaseHandler(kbId) {
+  const input = document.querySelector(`[data-rename-kb="${kbId}"]`);
+  const name = input?.value?.trim();
+  if (!name) return;
+  try {
+    await api(`/api/academy/knowledge-bases/${kbId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name })
+    });
+    state.knowledgeBases = (await api('/api/academy/knowledge-bases')).knowledgeBases || [];
+    renderKnowledgeBases();
+  } catch (e) {
+    alert(e.message || 'Не удалось переименовать базу знаний');
+  }
+}
+
+async function searchKnowledgeDocumentsHandler(kbId, query) {
+  if (state.activeKnowledgeBaseId !== kbId) return;
+  try {
+    const params = new URLSearchParams();
+    if (query?.trim()) params.set('q', query.trim());
+    const url = `/api/academy/knowledge-bases/${kbId}/documents/search${params.toString() ? `?${params}` : ''}`;
+    const docs = await api(url);
+    state.knowledgeDocuments = docs.documents || [];
+    renderKnowledgeDocuments(kbId);
+  } catch (e) {
+    alert(e.message || 'Не удалось выполнить поиск');
+  }
+}
+
+async function downloadDocumentHandler(documentId) {
+  try {
+    const token = getToken();
+    const res = await fetch(`${apiBase}/api/academy/knowledge-documents/${documentId}/download`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {}
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || res.statusText);
+    }
+    const blob = await res.blob();
+    const cd = res.headers.get('content-disposition') || '';
+    const match = cd.match(/filename="?([^"]+)"?/i);
+    const filename = match?.[1] || 'document';
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(a.href), 5000);
+  } catch (e) {
+    alert(e.message || 'Не удалось скачать документ');
   }
 }
 

--- a/routes/academy.js
+++ b/routes/academy.js
@@ -147,6 +147,26 @@ function createRouter({ JWT_SECRET }) {
     }
   });
 
+  router.patch('/knowledge-bases/:id', authenticateAcademy, async (req, res) => {
+    try {
+      const kb = await db.getKnowledgeBaseForUser(req.dbUser.id, req.params.id);
+      if (!kb) return res.status(404).json({ error: 'Knowledge base not found' });
+      const name = typeof req.body?.name === 'string' ? req.body.name.trim() : null;
+      const description = typeof req.body?.description === 'string' ? req.body.description.trim() : null;
+      if (name !== null && !name) {
+        return res.status(400).json({ error: 'Knowledge base name cannot be empty' });
+      }
+      const updated = await db.updateKnowledgeBase(req.dbUser.id, kb.id, {
+        name,
+        description
+      });
+      res.json(updated);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to update knowledge base' });
+    }
+  });
+
   router.get('/knowledge-bases/:id/documents', authenticateAcademy, async (req, res) => {
     try {
       const kb = await db.getKnowledgeBaseForUser(req.dbUser.id, req.params.id);
@@ -156,6 +176,23 @@ function createRouter({ JWT_SECRET }) {
     } catch (e) {
       console.error(e);
       res.status(500).json({ error: 'Failed to load documents' });
+    }
+  });
+
+  router.get('/knowledge-bases/:id/documents/search', authenticateAcademy, async (req, res) => {
+    try {
+      const kb = await db.getKnowledgeBaseForUser(req.dbUser.id, req.params.id);
+      if (!kb) return res.status(404).json({ error: 'Knowledge base not found' });
+      const q = String(req.query.q || '').trim();
+      if (!q) {
+        const docs = await db.listKnowledgeDocuments(req.dbUser.id, kb.id);
+        return res.json({ documents: docs });
+      }
+      const docs = await db.searchKnowledgeDocuments(req.dbUser.id, kb.id, q);
+      res.json({ documents: docs });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to search documents' });
     }
   });
 
@@ -208,6 +245,22 @@ function createRouter({ JWT_SECRET }) {
     } catch (e) {
       console.error(e);
       res.status(500).json({ error: 'Failed to delete document' });
+    }
+  });
+
+  router.get('/knowledge-documents/:id/download', authenticateAcademy, async (req, res) => {
+    try {
+      const doc = await db.getKnowledgeDocumentForUser(req.dbUser.id, req.params.id);
+      if (!doc) return res.status(404).json({ error: 'Document not found' });
+      const abs = path.join(userUploadDir(req.dbUser.id), doc.stored_name);
+      if (!fs.existsSync(abs)) {
+        return res.status(404).json({ error: 'Stored file not found' });
+      }
+      res.setHeader('Content-Type', doc.mime_type || 'application/octet-stream');
+      return res.download(abs, doc.original_name);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to download document' });
     }
   });
 

--- a/routes/academy.js
+++ b/routes/academy.js
@@ -2,6 +2,8 @@ const express = require('express');
 const jwt = require('jsonwebtoken');
 const rateLimit = require('express-rate-limit');
 const multer = require('multer');
+const fs = require('fs');
+const path = require('path');
 const db = require('../database');
 const { getMentorSystemPrompt, MENTOR_PROMPT_VERSION } = require('../prompts/mentorPrompt');
 const { createOpenRouterClient, getDefaultModel } = require('../services/ai/openRouterClient');
@@ -10,6 +12,7 @@ const {
   persistMulterFiles,
   buildUserContentForApi,
   estimatePayloadFootprintForLimits,
+  userUploadDir,
   MAX_FILES,
   MAX_FILE_BYTES
 } = require('../services/academy/multimodal');
@@ -87,6 +90,124 @@ function createRouter({ JWT_SECRET }) {
     } catch (e) {
       console.error(e);
       res.status(500).json({ error: 'Failed to save progress' });
+    }
+  });
+
+  router.get('/knowledge-bases', authenticateAcademy, async (req, res) => {
+    try {
+      const bases = await db.listKnowledgeBases(req.dbUser.id);
+      res.json({ knowledgeBases: bases });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to load knowledge bases' });
+    }
+  });
+
+  router.post('/knowledge-bases', authenticateAcademy, async (req, res) => {
+    try {
+      const name = String(req.body?.name || '').trim();
+      const description = String(req.body?.description || '').trim();
+      if (!name) {
+        return res.status(400).json({ error: 'Knowledge base name is required' });
+      }
+      const kb = await db.createKnowledgeBase(req.dbUser.id, {
+        name,
+        description: description || null
+      });
+      res.json(kb);
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to create knowledge base' });
+    }
+  });
+
+  router.delete('/knowledge-bases/:id', authenticateAcademy, async (req, res) => {
+    try {
+      const kb = await db.getKnowledgeBaseForUser(req.dbUser.id, req.params.id);
+      if (!kb) return res.status(404).json({ error: 'Knowledge base not found' });
+
+      const docs = await db.listKnowledgeDocuments(req.dbUser.id, kb.id);
+      for (const d of docs) {
+        if (!d.stored_name) continue;
+        const abs = path.join(userUploadDir(req.dbUser.id), d.stored_name);
+        if (fs.existsSync(abs)) {
+          try {
+            fs.unlinkSync(abs);
+          } catch (unlinkErr) {
+            console.warn('Failed to remove document file:', unlinkErr.message);
+          }
+        }
+      }
+
+      await db.deleteKnowledgeBase(req.dbUser.id, kb.id);
+      res.json({ ok: true });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to delete knowledge base' });
+    }
+  });
+
+  router.get('/knowledge-bases/:id/documents', authenticateAcademy, async (req, res) => {
+    try {
+      const kb = await db.getKnowledgeBaseForUser(req.dbUser.id, req.params.id);
+      if (!kb) return res.status(404).json({ error: 'Knowledge base not found' });
+      const docs = await db.listKnowledgeDocuments(req.dbUser.id, kb.id);
+      res.json({ documents: docs });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to load documents' });
+    }
+  });
+
+  router.post(
+    '/knowledge-bases/:id/documents',
+    authenticateAcademy,
+    upload.array('files', MAX_FILES),
+    async (req, res) => {
+      try {
+        const kb = await db.getKnowledgeBaseForUser(req.dbUser.id, req.params.id);
+        if (!kb) return res.status(404).json({ error: 'Knowledge base not found' });
+        if (!req.files?.length) return res.status(400).json({ error: 'Upload at least one file' });
+
+        const saved = persistMulterFiles(req.dbUser.id, req.files);
+        const created = [];
+        for (let i = 0; i < saved.length; i += 1) {
+          const item = saved[i];
+          const source = (req.files || [])[i];
+          created.push(
+            await db.addKnowledgeDocument(req.dbUser.id, kb.id, {
+              ...item,
+              sizeBytes: source?.size || 0
+            })
+          );
+        }
+        res.json({ documents: created });
+      } catch (e) {
+        console.error(e);
+        res.status(400).json({ error: e.message || 'Failed to upload documents' });
+      }
+    }
+  );
+
+  router.delete('/knowledge-documents/:id', authenticateAcademy, async (req, res) => {
+    try {
+      const doc = await db.getKnowledgeDocumentForUser(req.dbUser.id, req.params.id);
+      if (!doc) return res.status(404).json({ error: 'Document not found' });
+      if (doc.stored_name) {
+        const abs = path.join(userUploadDir(req.dbUser.id), doc.stored_name);
+        if (fs.existsSync(abs)) {
+          try {
+            fs.unlinkSync(abs);
+          } catch (unlinkErr) {
+            console.warn('Failed to remove document file:', unlinkErr.message);
+          }
+        }
+      }
+      await db.deleteKnowledgeDocument(req.dbUser.id, req.params.id);
+      res.json({ ok: true });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: 'Failed to delete document' });
     }
   });
 

--- a/services/academy/multimodal.js
+++ b/services/academy/multimodal.js
@@ -30,6 +30,10 @@ const ALLOWED_MIME = new Set([
 ]);
 
 function uploadsRoot() {
+  const configured = process.env.ACADEMY_UPLOADS_ROOT;
+  if (configured && String(configured).trim()) {
+    return path.resolve(String(configured).trim());
+  }
   return path.join(__dirname, '..', '..', 'uploads', 'academy');
 }
 

--- a/services/academy/multimodal.js
+++ b/services/academy/multimodal.js
@@ -274,6 +274,7 @@ function estimateContentChars(content) {
 
 module.exports = {
   uploadsRoot,
+  userUploadDir,
   persistMulterFiles,
   buildUserContentForApi,
   estimateContentChars,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add database schema for personal knowledge bases and their uploaded documents
- implement Academy API endpoints to create/list/update/delete knowledge bases and upload/list/search/download/delete documents
- physically delete uploaded files from disk when documents or whole knowledge bases are removed
- add Academy UI controls to manage knowledge bases and documents from the sidebar (create, rename, upload, search, download, delete)
- make uploads root configurable via `ACADEMY_UPLOADS_ROOT` for persistent disk setups (Render Disk)
- expose `userUploadDir` helper to share storage path logic between chat and KB APIs

## Testing
- `node --check routes/academy.js`
- `node --check public/js/academy-app.js`
- `node --check services/academy/multimodal.js`
- `node --check database.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ad6718-6ad6-4de0-977d-a4a0d9619907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ad6718-6ad6-4de0-977d-a4a0d9619907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

