### PR TITLE
Improve KB panel selection and chat send feedback UX

### DIFF
--- a/public/academy.html
+++ b/public/academy.html
@@ -124,7 +124,8 @@
           </header>
           <p id="modelHint" class="text-xs px-4 py-2 border-b" style="color: var(--cursor-muted); border-color: var(--cursor-border);"></p>
           <div id="messagesContainer" class="flex-1 overflow-y-auto chat-scroll px-4 py-4 space-y-6"></div>
-          <div id="typingRow" class="hidden px-4 pb-2 text-sm text-slate-500">
+          <div id="typingRow" class="hidden px-4 pb-2 text-sm text-slate-500 flex items-center gap-2">
+            <span id="typingLabel" class="text-xs">Нейросеть обрабатывает запрос...</span>
             <span class="typing-dot inline-block w-1.5 h-1.5 bg-slate-400 rounded-full mr-0.5"></span>
             <span class="typing-dot inline-block w-1.5 h-1.5 bg-slate-400 rounded-full mr-0.5"></span>
             <span class="typing-dot inline-block w-1.5 h-1.5 bg-slate-400 rounded-full"></span>
@@ -132,7 +133,7 @@
           <div class="p-4 border-t shrink-0" style="border-color: var(--cursor-border); background: var(--cursor-surface);">
             <div id="composerError" class="hidden mb-2 text-sm text-red-600"></div>
             <button type="button" id="retryBtn" class="hidden mb-2 text-xs text-indigo-600 hover:text-indigo-700">Повторить запрос</button>
-            <div class="flex gap-2 items-end">
+            <div class="flex gap-2 items-stretch">
               <div class="flex-1 flex flex-col gap-1 min-w-0">
                 <textarea id="composer" rows="2" class="w-full border rounded-xl px-3 py-2 text-sm resize-none text-slate-800" style="background: #ffffff; border-color: var(--cursor-border);" placeholder="Сообщение… (можно приложить файлы)"></textarea>
                 <div class="flex items-center gap-2 text-xs text-slate-500">
@@ -144,8 +145,8 @@
                 </div>
                 <div id="responseMeta" class="text-xs text-slate-500 hidden"></div>
               </div>
-              <div class="flex flex-col gap-2 shrink-0">
-                <button type="button" id="sendBtn" class="rounded-xl px-4 py-2 text-sm font-medium text-white disabled:opacity-40 transition-colors" style="background: var(--cursor-primary);">Отправить</button>
+              <div class="flex flex-col gap-2 shrink-0 justify-end">
+                <button type="button" id="sendBtn" class="rounded-xl px-4 py-2 text-sm font-medium text-white disabled:opacity-40 transition-colors h-full min-h-[74px]" style="background: var(--cursor-primary);">Отправить</button>
               </div>
             </div>
           </div>
@@ -167,6 +168,12 @@
           <div class="tool-panel is-active" data-tool-panel="kb">
             <h3 id="kbHeading" class="text-slate-900 font-medium mb-2">База знаний</h3>
             <div class="space-y-2">
+              <div class="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                <select id="kbActionSelect" class="sm:col-span-2 w-full rounded px-2 py-1.5 text-xs text-slate-800" style="border: 1px solid var(--cursor-border);">
+                  <option value="">Выберите базу знаний</option>
+                </select>
+                <button type="button" id="openSelectedKbBtn" class="text-xs rounded px-3 py-2 text-slate-800">Открыть</button>
+              </div>
               <input id="kbNameInput" type="text" placeholder="Название базы знаний" class="w-full rounded px-2 py-1.5 text-xs text-slate-800" style="border: 1px solid var(--cursor-border);" />
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <button type="button" id="createKbBtn" class="text-xs rounded px-3 py-2 text-slate-800">Создать KB</button>

--- a/public/css/modern-ui.css
+++ b/public/css/modern-ui.css
@@ -235,6 +235,7 @@ body.academy-theme #newChatBtn,
 body.academy-theme #sendBtn,
 body.academy-theme #createKbBtn,
 body.academy-theme #uploadKbBtn,
+body.academy-theme #openSelectedKbBtn,
 body.academy-theme #savePromptBtn,
 body.academy-theme #evaluatePromptBtn,
 body.academy-theme #runCompareBtn,
@@ -273,6 +274,7 @@ body.academy-theme #createAssistantBtn,
 body.academy-theme #runWorkflowBtn,
 body.academy-theme #hallucinationAttemptBtn,
 body.academy-theme #generateCertBtn,
+body.academy-theme #openSelectedKbBtn,
 body.academy-theme #regenerateBtn {
   color: #cbd5e1 !important;
   border-color: var(--modern-border) !important;
@@ -280,6 +282,7 @@ body.academy-theme #regenerateBtn {
 }
 
 body.academy-theme #regenerateBtn:hover,
+body.academy-theme #openSelectedKbBtn:hover,
 body.academy-theme #savePromptBtn:hover,
 body.academy-theme #evaluatePromptBtn:hover,
 body.academy-theme #runCompareBtn:hover,

--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -633,15 +633,26 @@ function updateModelHint() {
 
 function populateKnowledgeBases() {
   const sel = document.getElementById('knowledgeBaseSelect');
+  const actionSel = document.getElementById('kbActionSelect');
   if (!sel) return;
   sel.innerHTML = `<option value="">${tr('academy.controls.no_kb', 'Без базы знаний')}</option>`;
+  if (actionSel) {
+    actionSel.innerHTML = '<option value="">Выберите базу знаний</option>';
+  }
   for (const kb of state.knowledgeBases) {
     const o = document.createElement('option');
     o.value = kb.id;
     o.textContent = kb.name;
     sel.appendChild(o);
+    if (actionSel) {
+      const actionOption = document.createElement('option');
+      actionOption.value = kb.id;
+      actionOption.textContent = kb.name;
+      actionSel.appendChild(actionOption);
+    }
   }
   if (state.selectedKnowledgeBaseId) sel.value = state.selectedKnowledgeBaseId;
+  if (actionSel && state.selectedKnowledgeBaseId) actionSel.value = state.selectedKnowledgeBaseId;
 }
 
 function populatePersonas() {
@@ -840,6 +851,24 @@ function appendStreamingBubble() {
   wrap.appendChild(bubble);
   box.appendChild(wrap);
   return bubble;
+}
+
+function appendOptimisticUserMessage(message, files = []) {
+  const box = document.getElementById('messagesContainer');
+  if (!box) return;
+  const meta = files.length
+    ? {
+        files: files.map((file) => ({ name: file.name, size: file.size }))
+      }
+    : undefined;
+  box.appendChild(
+    renderMessageEl({
+      role: 'user',
+      content: message || '',
+      meta
+    })
+  );
+  box.scrollTop = box.scrollHeight;
 }
 
 async function streamChat(payload) {
@@ -1227,6 +1256,33 @@ function wireUi() {
       state.knowledgeDocuments = [];
       renderKnowledgeBases();
     }
+    await refreshKbStatus();
+  });
+  document.getElementById('kbActionSelect')?.addEventListener('change', async () => {
+    const selected = document.getElementById('kbActionSelect').value || null;
+    state.selectedKnowledgeBaseId = selected;
+    state.activeKnowledgeBaseId = selected;
+    const kbControl = document.getElementById('knowledgeBaseSelect');
+    if (kbControl) kbControl.value = selected || '';
+    if (selected) {
+      await openKnowledgeBase(selected);
+    } else {
+      state.knowledgeDocuments = [];
+      renderKnowledgeBases();
+    }
+    await refreshKbStatus();
+  });
+  document.getElementById('openSelectedKbBtn')?.addEventListener('click', async () => {
+    const selected = document.getElementById('kbActionSelect')?.value || state.selectedKnowledgeBaseId;
+    if (!selected) {
+      alert('Сначала выберите базу знаний.');
+      return;
+    }
+    state.selectedKnowledgeBaseId = selected;
+    state.activeKnowledgeBaseId = selected;
+    const kbControl = document.getElementById('knowledgeBaseSelect');
+    if (kbControl) kbControl.value = selected;
+    await openKnowledgeBase(selected);
     await refreshKbStatus();
   });
 
@@ -1685,6 +1741,10 @@ async function sendHandler() {
   const hasFiles = fileInput?.files?.length > 0;
   if (!text && !hasFiles) return;
 
+  const selectedFiles = fileInput?.files ? Array.from(fileInput.files) : [];
+  appendOptimisticUserMessage(text, selectedFiles);
+  const typingLabel = document.getElementById('typingLabel');
+  if (typingLabel) typingLabel.textContent = 'Нейросеть обрабатывает запрос...';
   document.getElementById('typingRow').classList.remove('hidden');
 
   const payload = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- added explicit KB selector inside the Knowledge Base tools panel (`kbActionSelect`) so a user can choose a base right there and immediately open/manage it
- synced KB selection across both controls (`knowledgeBaseSelect` in chat header and the new tools-panel selector)
- improved composer alignment so the `Отправить` button is visually aligned with the chat input block
- implemented optimistic chat send UX:
  - user message appears in chat immediately on submit
  - processing indicator appears right away with text `Нейросеть обрабатывает запрос...`

## Technical details
- `public/academy.html`
  - added KB action selector + open button in the tools KB section
  - adjusted composer layout for better send button alignment
  - added textual typing/processing label in `typingRow`
- `public/js/academy-app.js`
  - extended `populateKnowledgeBases()` to fill/sync both KB selectors
  - added listeners for new KB selector/open button
  - added `appendOptimisticUserMessage()` and wired it into `sendHandler()`
- `public/css/modern-ui.css`
  - styled the new `openSelectedKbBtn` to match panel controls

## Validation
- `node --check public/js/academy-app.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c63131b-7598-4f73-b120-eefde57f8bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c63131b-7598-4f73-b120-eefde57f8bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

