### PR TITLE
Fix stuck knowledge-base processing status updates

### DIFF
--- a/public/academy.html
+++ b/public/academy.html
@@ -172,7 +172,7 @@
                 <select id="kbActionSelect" class="sm:col-span-2 w-full rounded px-2 py-1.5 text-xs text-slate-800" style="border: 1px solid var(--cursor-border);">
                   <option value="">Выберите базу знаний</option>
                 </select>
-                <button type="button" id="openSelectedKbBtn" class="text-xs rounded px-3 py-2 text-slate-800">Открыть</button>
+                <button type="button" id="openSelectedKbBtn" class="text-xs rounded px-3 py-2 text-slate-800">Выбрать</button>
               </div>
               <input id="kbNameInput" type="text" placeholder="Название базы знаний" class="w-full rounded px-2 py-1.5 text-xs text-slate-800" style="border: 1px solid var(--cursor-border);" />
               <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
@@ -180,7 +180,8 @@
                 <button type="button" id="uploadKbBtn" class="text-xs rounded px-3 py-2 text-slate-800">Загрузить документы</button>
               </div>
               <input type="file" id="kbUploadInput" class="w-full text-xs text-slate-700" multiple />
-              <p class="text-[11px] text-slate-500">Управление: открыть, переименовать, поиск, скачивание и удаление файлов.</p>
+              <p class="text-[11px] text-slate-500">1) Выберите базу, 2) загрузите файлы, 3) дождитесь статуса "ГОТОВО".</p>
+              <p class="text-[11px] text-slate-500">Нижний список — ваши базы знаний. Внутри базы: Переименовать, Поиск, Скачать, Удалить.</p>
               <div id="kbStatusList" class="text-xs text-slate-600 space-y-1"></div>
               <ul id="knowledgeBaseList" class="space-y-2 pt-1"></ul>
             </div>

--- a/public/css/modern-ui.css
+++ b/public/css/modern-ui.css
@@ -441,9 +441,10 @@ body.academy-theme #kbStatusList {
   border-radius: 8px;
   background: rgba(30, 41, 59, 0.55);
   color: #cbd5e1;
-  font-size: 12px;
+  font-size: 11px;
   line-height: 1;
-  padding: 2px 6px;
+  padding: 4px 8px;
+  white-space: nowrap;
 }
 
 .icon-btn:hover {
@@ -486,6 +487,10 @@ body.academy-theme #kbStatusList {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.kb-actions .kb-meta {
+  font-size: 11px;
 }
 
 .kb-empty {

--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -413,6 +413,8 @@ const state = {
   activeKnowledgeBaseId: null,
   knowledgeDocuments: []
 };
+let kbStatusPollTimer = null;
+let kbStatusPollBusy = false;
 
 function currentLang() {
   return window.translationManager?.currentLanguage || localStorage.getItem('language') || 'ru';
@@ -678,24 +680,62 @@ function normalizeKbStatus(rawStatus) {
   return { css: 'status-pending', label: status || 'в обработке' };
 }
 
+function hasPendingKbStatus(rows) {
+  return (rows || []).some((d) => {
+    const status = String(d?.status || '').toLowerCase();
+    return ['uploaded', 'queued', 'processing', 'indexing', 'pending'].includes(status);
+  });
+}
+
+function stopKbStatusPolling() {
+  if (kbStatusPollTimer) {
+    clearInterval(kbStatusPollTimer);
+    kbStatusPollTimer = null;
+  }
+}
+
+function ensureKbStatusPolling() {
+  if (kbStatusPollTimer) return;
+  kbStatusPollTimer = setInterval(async () => {
+    if (kbStatusPollBusy || !state.selectedKnowledgeBaseId) return;
+    kbStatusPollBusy = true;
+    try {
+      const result = await refreshKbStatus();
+      if (!result.pending) {
+        stopKbStatusPolling();
+      }
+    } catch (_) {
+      /* keep timer; next tick can recover */
+    } finally {
+      kbStatusPollBusy = false;
+    }
+  }, 3500);
+}
+
 async function refreshKbStatus() {
   const box = document.getElementById('kbStatusList');
-  if (!box) return;
+  if (!box) return { rows: [], pending: false };
   box.innerHTML = '';
   if (!state.selectedKnowledgeBaseId) {
+    stopKbStatusPolling();
     const empty = document.createElement('div');
     empty.className = 'kb-empty';
     empty.textContent = tr('academy.kb.select_for_status', 'Выберите базу знаний для просмотра статусов.');
     box.appendChild(empty);
-    return;
+    return { rows: [], pending: false };
   }
   const rows = (await api(`/api/academy/knowledge-bases/${state.selectedKnowledgeBaseId}/documents`)).documents || [];
+  if (state.activeKnowledgeBaseId === state.selectedKnowledgeBaseId) {
+    state.knowledgeDocuments = rows;
+    renderKnowledgeDocuments(state.selectedKnowledgeBaseId);
+  }
   if (!rows.length) {
+    stopKbStatusPolling();
     const empty = document.createElement('div');
     empty.className = 'kb-empty';
     empty.textContent = tr('academy.kb.no_docs', 'Документов пока нет.');
     box.appendChild(empty);
-    return;
+    return { rows, pending: false };
   }
   rows.slice(0, 12).forEach((d) => {
     const row = document.createElement('div');
@@ -722,6 +762,10 @@ async function refreshKbStatus() {
     row.appendChild(delBtn);
     box.appendChild(row);
   });
+  const pending = hasPendingKbStatus(rows);
+  if (pending) ensureKbStatusPolling();
+  else stopKbStatusPolling();
+  return { rows, pending };
 }
 
 function parseMsgMeta(raw) {
@@ -1644,7 +1688,7 @@ async function uploadDocumentsHandler(kbId, inputEl) {
   }
   try {
     const token = getToken();
-    const res = await fetch(`${apiBase}/api/academy/knowledge-bases/${kbId}/documents`, {
+    const res = await fetch(`${apiBase}/api/academy/knowledge-bases/${kbId}/documents/upload`, {
       method: 'POST',
       headers: token ? { Authorization: `Bearer ${token}` } : {},
       body: fd

--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -1569,14 +1569,15 @@ function renderKnowledgeBases() {
     li.innerHTML = `
       <div class="kb-header">
         <button type="button" data-open-kb="${kb.id}" class="kb-open-btn ${isActive ? 'font-semibold' : ''} truncate">${escapeHtml(kb.name)}</button>
-        <span class="kb-meta">${kb.documents_count || 0}</span>
-        <button type="button" data-del-kb="${kb.id}" class="icon-btn danger">×</button>
+        <span class="kb-meta">${kb.documents_count || 0} док.</span>
+        <button type="button" data-del-kb="${kb.id}" class="icon-btn danger" title="Удалить базу">Удалить</button>
       </div>
       <div id="kb-docs-${kb.id}" class="${isActive ? 'kb-docs' : 'hidden kb-docs'}"></div>
       <div id="kb-actions-${kb.id}" class="${isActive ? 'kb-actions' : 'hidden kb-actions'}">
+        <div class="kb-meta">Переименовать базу</div>
         <div class="flex gap-1">
           <input type="text" data-rename-kb="${kb.id}" value="${escapeHtml(kb.name)}" class="flex-1 border rounded px-1 py-1 text-[10px]" />
-          <button type="button" data-save-kb="${kb.id}" class="icon-btn">OK</button>
+          <button type="button" data-save-kb="${kb.id}" class="icon-btn" title="Сохранить новое имя">Сохранить</button>
         </div>
         <input type="text" data-search-kb="${kb.id}" placeholder="Поиск документов..." class="w-full border rounded px-2 py-1 text-[10px]" />
         <input type="file" data-upload-kb="${kb.id}" class="text-[10px] w-full" multiple />
@@ -1618,8 +1619,8 @@ function renderKnowledgeDocuments(kbId) {
     row.innerHTML = `
       <span class="name" title="${escapeHtml(d.original_name)}">${escapeHtml(d.original_name)}</span>
       <span class="kb-meta">${formatBytes(d.size_bytes)}</span>
-      <button type="button" data-download-doc="${d.id}" class="icon-btn" title="Скачать">↓</button>
-      <button type="button" data-del-doc="${d.id}" class="icon-btn danger" title="Удалить">×</button>
+      <button type="button" data-download-doc="${d.id}" class="icon-btn" title="Скачать файл">Скачать</button>
+      <button type="button" data-del-doc="${d.id}" class="icon-btn danger" title="Удалить файл">Удалить</button>
     `;
     box.appendChild(row);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fixed KB document upload flow to use the indexing endpoint consistently (`/knowledge-bases/:id/documents/upload`) in the per-KB upload action
- added automatic status polling in academy UI while KB documents are in non-terminal states (`uploaded`, `queued`, `processing`, etc.)
- status polling now auto-stops once documents reach terminal states and also stops when KB is deselected
- while polling, active KB document list is refreshed so users can see status changes without manual refresh
- improved clarity of KB tools UI labels and actions:
  - changed `Открыть` to clearer `Выбрать`
  - replaced symbolic-only controls with explicit action labels (`Скачать`, `Удалить`, `Сохранить`)
  - added step-by-step helper text explaining how to use this block
  - clarified document counter label (`док.`)

## Why this fixes the issue
Previously, users could see `processing` and then no visible change because the UI fetched status once and did not continue refreshing. In addition, one upload path used a non-indexing endpoint. This patch ensures indexing is triggered and status transitions are reflected automatically.

## Validation
- `node --check public/js/academy-app.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c63131b-7598-4f73-b120-eefde57f8bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c63131b-7598-4f73-b120-eefde57f8bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

