### PR TITLE
fix: pass chatMode, knowledgeBaseId, strictMode, personaId in multipart FormData

### DIFF
--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -948,6 +948,10 @@ async function streamChat(payload) {
     if (payload.lessonId) fd.append('lessonId', payload.lessonId);
     if (payload.courseId) fd.append('courseId', payload.courseId);
     if (payload.regenerate) fd.append('regenerate', 'true');
+    if (payload.chatMode) fd.append('chatMode', payload.chatMode);
+    if (payload.knowledgeBaseId) fd.append('knowledgeBaseId', payload.knowledgeBaseId);
+    if (payload.strictMode) fd.append('strictMode', 'true');
+    if (payload.personaId) fd.append('personaId', payload.personaId);
     for (let i = 0; i < fileInput.files.length; i++) {
       fd.append('files', fileInput.files[i]);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема

При отправке сообщения с вложенным файлом запрос уходил как `multipart/form-data`, но в FormData не добавлялись поля `chatMode`, `knowledgeBaseId`, `strictMode` и `personaId`.

Из-за этого сервер всегда получал `chatMode = 'general'` и `knowledgeBaseId = null`, и база знаний никогда не подключалась к запросу — даже если пользователь выбрал режим «Строго по базе» и конкретную базу знаний.

## Исправление

В функции `streamChat` (`public/js/academy-app.js`) добавлены четыре поля в FormData при multipart-запросе:

```js
if (payload.chatMode) fd.append('chatMode', payload.chatMode);
if (payload.knowledgeBaseId) fd.append('knowledgeBaseId', payload.knowledgeBaseId);
if (payload.strictMode) fd.append('strictMode', 'true');
if (payload.personaId) fd.append('personaId', payload.personaId);
```

Теперь при отправке файла вместе с сообщением база знаний корректно используется в режимах `knowledge`, `strict_knowledge` и `agent_knowledge`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-459ad26d-cfad-43aa-88e4-d7eb4b7ce88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459ad26d-cfad-43aa-88e4-d7eb4b7ce88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

