### PR TITLE
fix: PDF вложения для gpt-4o-mini через извлечённый текст (совместимость OpenRouter)

### DIFF
--- a/routes/academy.js
+++ b/routes/academy.js
@@ -82,7 +82,7 @@ function createRouter({ JWT_SECRET }) {
    * Builds OpenRouter messages; truncates long assistant replies for token budget and drops
    * oldest turns until under MAX_CONTEXT_CHARS (CSV/HTML-heavy chats).
    */
-  async function buildMessagesWithBudget(rows, lessonForPrompt, req) {
+  async function buildMessagesWithBudget(rows, lessonForPrompt, req, modelId) {
     const maxAssist = parseInt(process.env.MAX_ASSISTANT_CHARS_IN_CONTEXT || '42000', 10);
     let subset = [...rows];
     let droppedTurns = 0;
@@ -98,7 +98,7 @@ function createRouter({ JWT_SECRET }) {
         if (m.role !== 'user' && m.role !== 'assistant') continue;
         let content;
         if (m.role === 'user') {
-          content = await buildUserContentForApi(m.content, req.dbUser.id, m.meta);
+          content = await buildUserContentForApi(m.content, req.dbUser.id, m.meta, modelId);
         } else {
           const raw = m.content || '';
           content =
@@ -1128,7 +1128,8 @@ function createRouter({ JWT_SECRET }) {
         const { apiMessages, totalChars, droppedTurns } = await buildMessagesWithBudget(
           rows,
           lessonForPrompt,
-          req
+          req,
+          model
         );
 
         if (personaId) {

--- a/services/academy/modelCatalog.js
+++ b/services/academy/modelCatalog.js
@@ -7,7 +7,7 @@ const MODEL_CATALOG = [
     id: 'openai/gpt-4o-mini',
     label: 'Экономно · текст',
     group: 'general',
-    hint: 'Быстрый текст и короткий контекст'
+    hint: 'Быстрый текст; PDF в чате — только извлечённый текст на сервере (сканы лучше через базу знаний или Gemini)'
   },
   {
     id: 'google/gemini-2.0-flash-001',

--- a/services/academy/multimodal.js
+++ b/services/academy/multimodal.js
@@ -73,6 +73,24 @@ function assertSafeStoredName(stored) {
   }
 }
 
+/**
+ * OpenRouter/gpt-4o-mini often ignores chat `file` PDF parts; Gemini handles them.
+ * For these models we never send native PDF — only server-extracted text (any length).
+ * Extend via ACADEMY_PDF_TEXT_ONLY_MODELS=comma,separated,model,ids
+ */
+function shouldForcePdfAsPlainText(modelId) {
+  if (!modelId || typeof modelId !== 'string') return false;
+  const extra = String(process.env.ACADEMY_PDF_TEXT_ONLY_MODELS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const defaults = ['openai/gpt-4o-mini'];
+  const ids = new Set([...defaults, ...extra]);
+  if (ids.has(modelId)) return true;
+  if (modelId.includes('gpt-4o-mini')) return true;
+  return false;
+}
+
 function looksLikeDelimitedTable(raw) {
   const lines = raw.split(/\r?\n/).filter((l) => l.length > 0).slice(0, 20);
   if (lines.length < 4) return false;
@@ -155,7 +173,8 @@ function compactJsonBuffer(buf, originalName) {
  * Build one OpenRouter content part from a saved file (async: PDF may use text extraction).
  * ACADEMY_PDF_MODE=text_first (default) | native — native = всегда отправлять PDF как file (дороже).
  */
-async function buildContentPartFromFile(absPath, mime, originalName) {
+async function buildContentPartFromFile(absPath, mime, originalName, options = {}) {
+  const modelId = options.model;
   const buf = fs.readFileSync(absPath);
   if (buf.length > MAX_FILE_BYTES) {
     throw new Error(`File too large (max ${MAX_FILE_BYTES / (1024 * 1024)} MB)`);
@@ -173,6 +192,43 @@ async function buildContentPartFromFile(absPath, mime, originalName) {
     const pdfMode = process.env.ACADEMY_PDF_MODE || 'text_first';
     const minChars = parseInt(process.env.ACADEMY_PDF_MIN_TEXT_CHARS || '80', 10);
     const maxChars = parseInt(process.env.ACADEMY_MAX_PDF_TEXT_CHARS || '80000', 10);
+    const forceTextPdf = shouldForcePdfAsPlainText(modelId);
+
+    if (forceTextPdf) {
+      try {
+        const { extractPdfText } = require('./pdfText');
+        const { text: rawText, numpages } = await extractPdfText(buf);
+        let body = rawText.replace(/\s+/g, ' ').trim();
+        if (body.length > maxChars) {
+          body =
+            body.slice(0, maxChars) +
+            '\n\n[… фрагмент обрезан (ACADEMY_MAX_PDF_TEXT_CHARS), чтобы уложиться в лимит токенов …]';
+        }
+        if (body.length > 0) {
+          const shortNote =
+            body.length < minChars
+              ? `\n\n[Внимание: извлечено мало текста (${body.length} симв.) — возможно скан; для разбора PDF «как файла» выберите модель Gemini или Claude с мультимодальностью.]\n\n`
+              : '\n\n';
+          return {
+            type: 'text',
+            text:
+              `[PDF «${originalName || 'документ.pdf'}», ~${numpages} стр. Текст извлечён на сервере (совместимость с выбранной моделью).]${shortNote}${body}`
+          };
+        }
+        return {
+          type: 'text',
+          text:
+            `[PDF «${originalName || 'документ.pdf'}»] Текст не извлечён (часто у сканов). Эта модель не получает нативный PDF в чате — загрузите документ в базу знаний, приложите текстовый PDF или выберите модель Gemini.`
+        };
+      } catch (e) {
+        console.warn('PDF text extraction failed (text-only model path):', e.message);
+        return {
+          type: 'text',
+          text:
+            `[PDF «${originalName || 'документ.pdf'}»] Ошибка извлечения: ${e.message}. Попробуйте модель Gemini или загрузите файл в базу знаний.`
+        };
+      }
+    }
 
     if (pdfMode !== 'native') {
       try {
@@ -299,7 +355,7 @@ function persistMulterFiles(userId, multerFiles) {
 /**
  * Build message content for OpenRouter: string or multimodal array.
  */
-async function buildUserContentForApi(text, userId, meta) {
+async function buildUserContentForApi(text, userId, meta, modelId) {
   const t = (text || '').trim();
   let m = meta;
   if (typeof m === 'string') {
@@ -333,7 +389,9 @@ async function buildUserContentForApi(text, userId, meta) {
       continue;
     }
     parts.push(
-      await buildContentPartFromFile(abs, f.mime || 'application/octet-stream', f.name)
+      await buildContentPartFromFile(abs, f.mime || 'application/octet-stream', f.name, {
+        model: modelId
+      })
     );
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Причина

`openai/gpt-4o-mini` через OpenRouter часто **не получает** части сообщения с `type: file` и PDF — ответ получается как «не могу открыть вложение». Модели вроде **Gemini** нормально принимают нативный PDF, поэтому там всё работало.

Раньше при коротком извлечённом тексте (&lt; `ACADEMY_PDF_MIN_TEXT_CHARS`) код переходил на отправку PDF как `file`, что для mini по сути ломало доступ к содержимому.

## Что сделано

- В контекст сборки сообщений передаётся **выбранная модель**.
- Для **gpt-4o-mini** (и опционально списка `ACADEMY_PDF_TEXT_ONLY_MODELS`) PDF **никогда** не отправляется как нативный `file`: только **текст, извлечённый на сервере** (любой длины), либо понятное текстовое сообщение при пустом извлечении / ошибке (скан, защита и т.д.).
- Подсказка в каталоге моделей для «Экономно · текст» обновлена.

После деплоя проверка договора в режиме mini должна опираться на извлечённый текст и базу знаний как раньше, без «слепой» модели.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-459ad26d-cfad-43aa-88e4-d7eb4b7ce88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-459ad26d-cfad-43aa-88e4-d7eb4b7ce88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

