### PR TITLE
feat(academy): MVP practice — assignments, AI feedback, progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://user:pass@localhost:5432/academy
+JWT_SECRET=change-me
+OPENROUTER_API_KEY=
+OPENROUTER_DEFAULT_MODEL=openai/gpt-4o-mini
+PORT=3000

--- a/database.js
+++ b/database.js
@@ -115,6 +115,19 @@ async function migrateDeprecatedOpenRouterModelIds(client) {
   }
 }
 
+async function migrateAcademyProgressColumns(client) {
+  const sqls=[
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS answer_text TEXT",
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS answer_updated_at TIMESTAMPTZ",
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS assignment_status VARCHAR(30) DEFAULT 'not_started'",
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS feedback_json JSONB DEFAULT '{}'::jsonb",
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS feedback_at TIMESTAMPTZ",
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS practice_mode VARCHAR(20)",
+    "ALTER TABLE academy_user_lesson_progress ADD COLUMN IF NOT EXISTS group_meta JSONB DEFAULT '{}'::jsonb"
+  ];
+  for (const sql of sqls) await client.query(sql);
+}
+
 async function seedAcademyCatalog(client) {
   const courses = [
     { slug: 'ai-basics', title: 'Основы AI', description: 'Что такое нейросети и как они работают', sort_order: 1 },
@@ -524,6 +537,7 @@ async function initializeDatabase() {
       CREATE INDEX IF NOT EXISTS idx_kd_kb_created ON knowledge_documents(knowledge_base_id, created_at DESC);
     `);
 
+    await migrateAcademyProgressColumns(client);
     await seedAcademyCatalog(client);
     await bootstrapAdminEmail(client);
     await mergeExistingUsersAiAllowedModels(client);
@@ -1128,6 +1142,126 @@ async function getLessonProgressForUser(userId) {
       [userId]
     );
     return r.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function getAssignmentByLessonId(lessonId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(`SELECT * FROM academy_assignments WHERE lesson_id = $1`, [lessonId]);
+    return r.rows[0] || null;
+  } finally {
+    client.release();
+  }
+}
+
+async function getLessonSubmission(userId, lessonId) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `SELECT * FROM academy_user_lesson_progress WHERE user_id = $1 AND lesson_id = $2`,
+      [userId, lessonId]
+    );
+    return r.rows[0] || null;
+  } finally {
+    client.release();
+  }
+}
+
+async function upsertLessonSubmission(userId, lessonId, data) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `INSERT INTO academy_user_lesson_progress
+        (user_id, lesson_id, status, answer_text, answer_updated_at, assignment_status, practice_mode, group_meta, updated_at)
+       VALUES ($1, $2, COALESCE($3, 'in_progress'), $4, CURRENT_TIMESTAMP, COALESCE($5, 'draft'), $6, COALESCE($7::jsonb, '{}'::jsonb), CURRENT_TIMESTAMP)
+       ON CONFLICT (user_id, lesson_id) DO UPDATE SET
+         answer_text = COALESCE(EXCLUDED.answer_text, academy_user_lesson_progress.answer_text),
+         answer_updated_at = CASE WHEN EXCLUDED.answer_text IS NOT NULL THEN CURRENT_TIMESTAMP ELSE academy_user_lesson_progress.answer_updated_at END,
+         assignment_status = COALESCE(EXCLUDED.assignment_status, academy_user_lesson_progress.assignment_status),
+         practice_mode = COALESCE(EXCLUDED.practice_mode, academy_user_lesson_progress.practice_mode),
+         group_meta = COALESCE(EXCLUDED.group_meta, academy_user_lesson_progress.group_meta),
+         updated_at = CURRENT_TIMESTAMP
+       RETURNING *`,
+      [
+        userId,
+        lessonId,
+        data.status || 'in_progress',
+        data.answer_text ?? null,
+        data.assignment_status ?? null,
+        data.practice_mode ?? null,
+        data.group_meta != null ? JSON.stringify(data.group_meta) : null
+      ]
+    );
+    return r.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function saveLessonFeedback(userId, lessonId, { feedbackJson, score, assignmentStatus }) {
+  const client = await pool.connect();
+  try {
+    const r = await client.query(
+      `INSERT INTO academy_user_lesson_progress
+        (user_id, lesson_id, status, feedback_json, feedback_at, score, assignment_status, updated_at)
+       VALUES ($1, $2, 'in_progress', $3::jsonb, CURRENT_TIMESTAMP, $4, COALESCE($5, 'reviewed'), CURRENT_TIMESTAMP)
+       ON CONFLICT (user_id, lesson_id) DO UPDATE SET
+         feedback_json = EXCLUDED.feedback_json,
+         feedback_at = CURRENT_TIMESTAMP,
+         score = COALESCE(EXCLUDED.score, academy_user_lesson_progress.score),
+         assignment_status = COALESCE(EXCLUDED.assignment_status, academy_user_lesson_progress.assignment_status),
+         updated_at = CURRENT_TIMESTAMP
+       RETURNING *`,
+      [userId, lessonId, JSON.stringify(feedbackJson || {}), score ?? null, assignmentStatus || 'reviewed']
+    );
+    return r.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function getProgressSummary(userId) {
+  const client = await pool.connect();
+  try {
+    const lessons = await client.query(
+      `SELECT l.id, l.title, l.scenario_key FROM academy_lessons l
+       JOIN academy_courses c ON c.id = l.course_id WHERE c.slug = 'ai-work-business-talk' ORDER BY l.sort_order`
+    );
+    const progress = await client.query(`SELECT * FROM academy_user_lesson_progress WHERE user_id = $1`, [userId]);
+    const progressMap = {};
+    for (const p of progress.rows) progressMap[p.lesson_id] = p;
+    const practiceLessons = lessons.rows.filter((l) => l.scenario_key && l.scenario_key.startsWith('block1-practice'));
+    let completed = 0;
+    const lessonStatuses = practiceLessons.map((l) => {
+      const p = progressMap[l.id];
+      if (p?.status === 'completed') completed += 1;
+      return {
+        lesson_id: l.id,
+        title: l.title,
+        assignment_status: p?.assignment_status || 'not_started',
+        has_feedback: !!(p?.feedback_json && Object.keys(p.feedback_json).length),
+        status: p?.status || 'not_started'
+      };
+    });
+    const lastActivity = await client.query(
+      `SELECT GREATEST(
+         COALESCE((SELECT MAX(updated_at) FROM academy_user_lesson_progress WHERE user_id = $1), 'epoch'::timestamptz),
+         COALESCE((SELECT MAX(updated_at) FROM ai_conversations WHERE user_id = $1), 'epoch'::timestamptz)
+       ) AS last_activity_at`,
+      [userId]
+    );
+    const total = practiceLessons.length || 1;
+    return {
+      course_slug: 'ai-work-business-talk',
+      practices_completed: completed,
+      practices_total: total,
+      percent: Math.round((completed / total) * 100),
+      last_activity_at: lastActivity.rows[0]?.last_activity_at || null,
+      lessons: lessonStatuses
+    };
   } finally {
     client.release();
   }

--- a/prompts/mentorPrompt.js
+++ b/prompts/mentorPrompt.js
@@ -3,17 +3,20 @@
  */
 const MENTOR_PROMPT_VERSION = '5';
 
-function buildLessonSection(lesson) {
+function buildLessonSection(lesson, assignment = null) {
   if (!lesson) return '';
   const parts = [];
   if (lesson.course_title) parts.push(`Course: ${lesson.course_title}`);
   if (lesson.title) parts.push(`Lesson: ${lesson.title}`);
   if (lesson.content_md) parts.push(`Lesson material:\n${lesson.content_md}`);
+  if (assignment?.instructions_md) {
+    parts.push(`Current assignment (${assignment.title || 'Practice'}):\n${assignment.instructions_md}`);
+  }
   return parts.join('\n');
 }
 
-function getMentorSystemPrompt({ lesson = null } = {}) {
-  const lessonBlock = buildLessonSection(lesson);
+function getMentorSystemPrompt({ lesson = null, assignment = null } = {}) {
+  const lessonBlock = buildLessonSection(lesson, assignment);
 
   return `You are an AI learning mentor on an educational platform (prompt version ${MENTOR_PROMPT_VERSION}).
 

--- a/public/academy.html
+++ b/public/academy.html
@@ -212,10 +212,14 @@
             <pre id="builderOutput" class="mt-2 text-xs text-slate-600 whitespace-pre-wrap max-h-48 overflow-y-auto"></pre>
           </div>
           <div class="tool-panel" data-tool-panel="training">
-            <h3 id="trainingHeading" class="text-slate-900 font-medium mb-2">Тренировка галлюцинаций и сертификат</h3>
+            <h3 id="trainingHeading" class="text-slate-900 font-medium mb-2">Тренировка галлюцинаций</h3>
+            <select id="hallucinationScenarioSelect" class="w-full border rounded text-xs mb-2"></select>
+            <div id="hallucinationFlawed" class="text-xs p-2 mb-2 rounded bg-amber-50 border"></div>
+            <select id="hallucinationIssueSelect" class="w-full border rounded text-xs mb-2"></select>
+            <textarea id="hallucinationExplanation" rows="2" class="w-full border rounded text-xs mb-2" placeholder="Объяснение"></textarea>
             <div class="flex flex-wrap gap-2">
-              <button type="button" id="hallucinationAttemptBtn" class="text-xs rounded px-3 py-1.5 text-slate-800">Отправить попытку</button>
-              <button type="button" id="generateCertBtn" class="text-xs rounded px-3 py-1.5 text-slate-800">Сгенерировать сертификат</button>
+              <button type="button" id="hallucinationAttemptBtn" class="text-xs rounded px-3 py-1.5 text-slate-800">Проверить</button>
+              <button type="button" id="generateCertBtn" class="text-xs rounded px-3 py-1.5 text-slate-800">Сертификат</button>
             </div>
             <pre id="trainingOutput" class="mt-2 text-xs text-slate-600 whitespace-pre-wrap"></pre>
           </div>

--- a/public/js/academy-app.js
+++ b/public/js/academy-app.js
@@ -398,11 +398,18 @@ function initMermaid() {
   });
 }
 
+const MVP_COURSE_SLUG = 'ai-work-business-talk';
+
 const state = {
   catalog: null,
   conversations: [],
   currentConversationId: null,
   currentLessonId: null,
+  currentLesson: null,
+  progressSummary: null,
+  compareSessionId: null,
+  hallucinationScenarios: [],
+  promptLibrary: [],
   usage: null,
   streaming: false,
   selectedModel: null,
@@ -495,6 +502,10 @@ async function init() {
     await refreshKbStatus();
     updateModelHint();
     applyAcademyTranslations();
+    renderCourseTree();
+    await loadProgressSummary();
+    await loadPromptLibrary();
+    await loadHallucinationScenarios();
     showApp();
   } catch (e) {
     if (e.status === 401 || e.status === 403) {
@@ -517,16 +528,130 @@ function renderUsage() {
   document.getElementById('usageBadge').textContent = `День: ${dayPct}% · ${d.used_tokens}/${d.limit_tokens} tok`;
 }
 
+
+function getMvpCourses() {
+  if (!state.catalog?.courses) return [];
+  const mvp = state.catalog.courses.filter((c) => c.slug === MVP_COURSE_SLUG);
+  return mvp.length ? mvp : state.catalog.courses;
+}
+function getMvpLessons() {
+  const ids = new Set(getMvpCourses().map((c) => c.id));
+  return (state.catalog?.lessons || []).filter((l) => ids.has(l.course_id));
+}
+async function loadProgressSummary() {
+  try { state.progressSummary = await api('/api/academy/progress/summary'); renderProgressSummary(); } catch (_) {}
+}
+function renderProgressSummary() {
+  const el = document.getElementById('progressSummaryText');
+  if (!el) return;
+  const s = state.progressSummary;
+  if (!s) { el.textContent = '—'; return; }
+  el.textContent = `Практик: ${s.practices_completed}/${s.practices_total} (${s.percent}%)`;
+}
+function syncPracticeModeUi() {
+  const g = document.getElementById('practiceModeSelect')?.value === 'group';
+  document.getElementById('groupMetaFields')?.classList.toggle('hidden', !g);
+  document.getElementById('groupModeCallout')?.classList.toggle('hidden', !g);
+}
+function renderAssignmentFeedback(fb) {
+  const box = document.getElementById('assignmentFeedback');
+  if (!box || !fb) return;
+  box.classList.remove('hidden');
+  const lines = [];
+  if (fb.score != null) lines.push('Оценка: ' + fb.score + '/10');
+  if (fb.recommendations?.length) lines.push('Рекомендации:\n• ' + fb.recommendations.join('\n• '));
+  if (fb.strengths?.length) lines.push('Сильные:\n• ' + fb.strengths.join('\n• '));
+  if (fb.weaknesses?.length) lines.push('Слабые:\n• ' + fb.weaknesses.join('\n• '));
+  box.textContent = lines.join('\n\n');
+}
+async function loadSubmissionForLesson(lessonId) {
+  const data = await api('/api/academy/lessons/' + lessonId + '/submission');
+  if (data.submission?.answer_text) document.getElementById('assignmentAnswer').value = data.submission.answer_text;
+  if (data.submission?.practice_mode) document.getElementById('practiceModeSelect').value = data.submission.practice_mode;
+  syncPracticeModeUi();
+  let fj = data.submission?.feedback_json;
+  if (typeof fj === 'string') try { fj = JSON.parse(fj); } catch { fj = null; }
+  if (fj && Object.keys(fj).length) renderAssignmentFeedback(fj);
+}
+async function saveSubmission(status) {
+  if (!state.currentLessonId) return;
+  await api('/api/academy/lessons/' + state.currentLessonId + '/submission', {
+    method: 'PUT',
+    body: JSON.stringify({
+      answer_text: document.getElementById('assignmentAnswer')?.value?.trim() || '',
+      assignment_status: status,
+      practice_mode: document.getElementById('practiceModeSelect')?.value || 'individual',
+      group_meta: { size: Number(document.getElementById('groupSizeInput')?.value) || null, input_by: document.getElementById('groupInputBy')?.value?.trim() || null }
+    })
+  });
+}
+async function loadPromptLibrary() {
+  try { const d = await api('/api/academy/prompts'); state.promptLibrary = d.prompts || []; renderPromptLibrary(); } catch (_) {}
+}
+function renderPromptLibrary() {
+  const ul = document.getElementById('promptLibraryList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  for (const pr of state.promptLibrary) {
+    const li = document.createElement('li');
+    li.textContent = pr.title + ' (' + (pr.category || '') + ')';
+    ul.appendChild(li);
+  }
+}
+function renderCompareResults(data) {
+  const box = document.getElementById('compareOutput');
+  if (!box) return;
+  box.innerHTML = '';
+  state.compareSessionId = data.session_id;
+  (data.results || []).forEach((r) => {
+    const d = document.createElement('div');
+    d.className = 'compare-col text-xs mb-2';
+    d.innerHTML = '<b>' + escapeHtml(r.model) + '</b><pre class="whitespace-pre-wrap max-h-20 overflow-auto">' + escapeHtml((r.response||'').slice(0,800)) + '</pre><label><input type="radio" name="cc" value="' + escapeHtml(r.model) + '"> Лучший</label>';
+    box.appendChild(d);
+  });
+  const b = document.createElement('button');
+  b.textContent = 'Сохранить выбор';
+  b.className = 'text-xs text-indigo-700 mt-1';
+  b.onclick = async () => {
+    const c = document.querySelector('input[name=cc]:checked');
+    if (!c || !state.compareSessionId) return alert('Выберите модель');
+    await api('/api/academy/model-compare/' + state.compareSessionId + '/choice', { method: 'POST', body: JSON.stringify({ chosen_model: c.value }) });
+    document.getElementById('compareChoiceHint').textContent = 'Сохранено: ' + c.value;
+  };
+  box.appendChild(b);
+}
+async function loadHallucinationScenarios() {
+  try {
+    const d = await api('/api/academy/hallucination/scenarios');
+    state.hallucinationScenarios = d.scenarios || [];
+    const sel = document.getElementById('hallucinationScenarioSelect');
+    if (!sel) return;
+    sel.innerHTML = '';
+    state.hallucinationScenarios.forEach((s) => { const o = document.createElement('option'); o.value = s.id; o.textContent = s.title; sel.appendChild(o); });
+    renderHallucinationScenarioUi();
+  } catch (_) {}
+}
+function renderHallucinationScenarioUi() {
+  const s = state.hallucinationScenarios.find((x) => x.id === document.getElementById('hallucinationScenarioSelect')?.value);
+  if (!s) return;
+  document.getElementById('hallucinationFlawed').textContent = s.flawed_answer || '';
+  const is = document.getElementById('hallucinationIssueSelect');
+  is.innerHTML = '';
+  let types = s.issue_types;
+  if (typeof types === 'string') try { types = JSON.parse(types); } catch { types = []; }
+  (types || []).forEach((t) => { const o = document.createElement('option'); o.value = t; o.textContent = t; is.appendChild(o); });
+}
+
 function renderCourseTree() {
   const root = document.getElementById('courseTree');
-  if (!root) return;
+  if (!root || !state.catalog) return;
   root.innerHTML = '';
   const byCourse = {};
-  for (const l of state.catalog.lessons) {
+  for (const l of getMvpLessons()) {
     if (!byCourse[l.course_id]) byCourse[l.course_id] = [];
     byCourse[l.course_id].push(l);
   }
-  for (const c of state.catalog.courses) {
+  for (const c of getMvpCourses()) {
     const wrap = document.createElement('div');
     wrap.innerHTML = `<div class="font-medium text-slate-800 mb-1">${escapeHtml(c.title)}</div>`;
     const ul = document.createElement('ul');
@@ -792,33 +917,31 @@ function parseMsgMeta(raw) {
 
 async function selectLesson(lesson) {
   if (!lesson) return;
-  const lessonEmpty = document.getElementById('lessonEmpty');
-  const lessonContent = document.getElementById('lessonContent');
-  const assignmentBlock = document.getElementById('assignmentBlock');
-  const assignmentText = document.getElementById('assignmentText');
   state.currentLessonId = lesson.id;
-  lessonEmpty?.classList.add('hidden');
-  lessonContent?.classList.remove('hidden');
-  if (lessonContent) lessonContent.innerHTML = renderMarkdown(lesson.content_md || '');
-  document.getElementById('lessonHint').textContent = `${lesson.course_title || ''} · ${lesson.title}`;
+  state.currentLesson = lesson;
+  document.getElementById('lessonEmpty')?.classList.add('hidden');
+  document.getElementById('lessonContent')?.classList.remove('hidden');
+  const lc = document.getElementById('lessonContent');
+  if (lc) lc.innerHTML = renderMarkdown(lesson.content_md || '');
+  document.getElementById('lessonHint').textContent = (lesson.course_title || '') + ' · ' + lesson.title;
+  const ab = document.getElementById('assignmentBlock');
+  const at = document.getElementById('assignmentText');
   const asn = lesson.assignment;
-  if (asn && assignmentBlock && assignmentText) {
-    assignmentBlock.classList.remove('hidden');
-    assignmentText.textContent = asn.instructions_md || '';
+  if (asn && ab && at) {
+    ab.classList.remove('hidden');
+    document.getElementById('assignmentTitle').textContent = asn.title || 'Задание';
+    at.innerHTML = renderMarkdown(asn.instructions_md || '');
+    document.getElementById('askMentorAssignmentBtn')?.classList.remove('hidden');
   } else {
-    assignmentBlock?.classList.add('hidden');
+    ab?.classList.add('hidden');
+    document.getElementById('askMentorAssignmentBtn')?.classList.add('hidden');
   }
-
-  const conv = await api('/api/academy/conversations', {
-    method: 'POST',
-    body: JSON.stringify({
-      lessonId: lesson.id,
-      courseId: lesson.course_id,
-      title: lesson.title,
-      model: document.getElementById('modelSelect').value
-    })
-  });
-  state.conversations.unshift(conv);
+  try { await loadSubmissionForLesson(lesson.id); } catch (e) { console.warn(e); }
+  let conv = state.conversations.find((c) => c.lesson_id === lesson.id);
+  if (!conv) {
+    conv = await api('/api/academy/conversations', { method: 'POST', body: JSON.stringify({ lessonId: lesson.id, courseId: lesson.course_id, title: lesson.title, model: document.getElementById('modelSelect').value }) });
+    state.conversations.unshift(conv);
+  }
   state.currentConversationId = conv.id;
   renderConversationList();
   await loadConversation(conv.id, { skipFetchList: true });
@@ -1394,13 +1517,22 @@ function wireUi() {
   });
 
   document.getElementById('evaluatePromptBtn')?.addEventListener('click', async () => {
-    const text = document.getElementById('composer').value.trim();
+    const text =
+      document.getElementById('promptTrainerInput')?.value.trim() ||
+      document.getElementById('assignmentAnswer')?.value.trim() ||
+      document.getElementById('composer').value.trim();
     if (!text) return;
     const out = await api('/api/academy/prompt-evaluate', {
       method: 'POST',
       body: JSON.stringify({ prompt: text, model: document.getElementById('modelSelect').value })
     });
     document.getElementById('promptEvalOutput').textContent = JSON.stringify(out, null, 2);
+    const wrap = document.getElementById('promptCompareBeforeAfter');
+    if (wrap && out.improved_prompt) {
+      wrap.classList.remove('hidden');
+      document.getElementById('promptBefore').textContent = text;
+      document.getElementById('promptAfter').textContent = out.improved_prompt;
+    }
   });
 
   document.getElementById('runCompareBtn')?.addEventListener('click', async () => {
@@ -1415,7 +1547,7 @@ function wireUi() {
       method: 'POST',
       body: JSON.stringify({ prompt: text, models })
     });
-    document.getElementById('compareOutput').textContent = JSON.stringify(out, null, 2);
+    renderCompareResults(out);
   });
 
   document.getElementById('runPlaygroundBtn')?.addEventListener('click', async () => {
@@ -1475,21 +1607,13 @@ function wireUi() {
   });
 
   document.getElementById('hallucinationAttemptBtn')?.addEventListener('click', async () => {
-    const scenarios = await api('/api/academy/hallucination/scenarios');
-    if (!scenarios.scenarios?.length) {
-      document.getElementById('trainingOutput').textContent = 'No scenarios yet.';
-      return;
-    }
-    const first = scenarios.scenarios[0];
-    const out = await api('/api/academy/hallucination/attempt', {
-      method: 'POST',
-      body: JSON.stringify({
-        scenario_id: first.id,
-        selected_issue: 'unsupported claim',
-        explanation: 'The answer states facts without evidence and shows overconfidence.'
-      })
-    });
-    document.getElementById('trainingOutput').textContent = JSON.stringify(out, null, 2);
+    const scenarioId = document.getElementById('hallucinationScenarioSelect')?.value;
+    const selected_issue = document.getElementById('hallucinationIssueSelect')?.value;
+    const explanation = document.getElementById('hallucinationExplanation')?.value?.trim();
+    if (!scenarioId || !selected_issue || !explanation) return alert('Заполните поля');
+    const out = await api('/api/academy/hallucination/attempt', { method: 'POST', body: JSON.stringify({ scenario_id: scenarioId, selected_issue, explanation }) });
+    document.getElementById('trainingOutput').textContent = 'Оценка: ' + out.attempt?.score + '/10\n' + (out.attempt?.feedback || '');
+    if (state.currentLessonId) { document.getElementById('assignmentAnswer').value = selected_issue + ': ' + explanation; await saveSubmission('submitted'); }
   });
 
   document.getElementById('generateCertBtn')?.addEventListener('click', async () => {
@@ -1549,6 +1673,26 @@ function wireUi() {
     document.getElementById('typingRow').classList.add('hidden');
   });
 
+
+  document.getElementById('practiceModeSelect')?.addEventListener('change', syncPracticeModeUi);
+  document.getElementById('saveAnswerBtn')?.addEventListener('click', async () => { try { await saveSubmission('draft'); alert('Сохранено'); } catch(e){alert(e.message);} });
+  document.getElementById('submitAnswerBtn')?.addEventListener('click', async () => { try { await saveSubmission('submitted'); alert('Отправлено'); } catch(e){alert(e.message);} });
+  document.getElementById('requestFeedbackBtn')?.addEventListener('click', async () => {
+    if (!state.currentLessonId) return;
+    const answer_text = document.getElementById('assignmentAnswer')?.value?.trim();
+    if (!answer_text) return alert('Введите ответ');
+    await saveSubmission('submitted');
+    const out = await api('/api/academy/lessons/' + state.currentLessonId + '/feedback', { method: 'POST', body: JSON.stringify({ answer_text, model: document.getElementById('modelSelect').value }) });
+    renderAssignmentFeedback(out.feedback);
+    state.catalog = await api('/api/academy/catalog');
+    renderCourseTree();
+    await loadProgressSummary();
+  });
+  document.getElementById('askMentorAssignmentBtn')?.addEventListener('click', () => {
+    document.getElementById('composer').value = 'Помоги с практическим заданием (не делай за меня).';
+    document.getElementById('composer').focus();
+  });
+
   document.getElementById('markDoneBtn')?.addEventListener('click', async () => {
     if (!state.currentLessonId) return;
     await api('/api/academy/progress', {
@@ -1557,6 +1701,7 @@ function wireUi() {
     });
     state.catalog = await api('/api/academy/catalog');
     renderCourseTree();
+    await loadProgressSummary();
   });
 }
 

--- a/routes/academy.js
+++ b/routes/academy.js
@@ -82,7 +82,7 @@ function createRouter({ JWT_SECRET }) {
    * Builds OpenRouter messages; truncates long assistant replies for token budget and drops
    * oldest turns until under MAX_CONTEXT_CHARS (CSV/HTML-heavy chats).
    */
-  async function buildMessagesWithBudget(rows, lessonForPrompt, req, modelId) {
+  async function buildMessagesWithBudget(rows, lessonForPrompt, req, modelId, assignmentForPrompt = null) {
     const maxAssist = parseInt(process.env.MAX_ASSISTANT_CHARS_IN_CONTEXT || '42000', 10);
     let subset = [...rows];
     let droppedTurns = 0;
@@ -91,7 +91,7 @@ function createRouter({ JWT_SECRET }) {
       const apiMessages = [];
       apiMessages.push({
         role: 'system',
-        content: getMentorSystemPrompt({ lesson: lessonForPrompt })
+        content: getMentorSystemPrompt({ lesson: lessonForPrompt, assignment: assignmentForPrompt })
       });
       let totalChars = estimatePayloadFootprintForLimits(apiMessages[0].content);
       for (const m of subset) {
@@ -149,6 +149,56 @@ function createRouter({ JWT_SECRET }) {
     }
   });
 
+
+  router.get('/progress/summary', authenticateAcademy, async (req, res) => {
+    try { res.json(await db.getProgressSummary(req.dbUser.id)); }
+    catch (e) { console.error(e); res.status(500).json({ error: 'Failed to load progress summary' }); }
+  });
+  router.get('/lessons/:lessonId/submission', authenticateAcademy, async (req, res) => {
+    try {
+      const lesson = await db.getLessonById(req.params.lessonId);
+      if (!lesson) return res.status(404).json({ error: 'Lesson not found' });
+      res.json({ lesson, assignment: await db.getAssignmentByLessonId(req.params.lessonId), submission: await db.getLessonSubmission(req.dbUser.id, req.params.lessonId) });
+    } catch (e) { console.error(e); res.status(500).json({ error: 'Failed to load submission' }); }
+  });
+  router.put('/lessons/:lessonId/submission', authenticateAcademy, async (req, res) => {
+    try {
+      if (!await db.getLessonById(req.params.lessonId)) return res.status(404).json({ error: 'Lesson not found' });
+      const b = req.body || {};
+      const submission = await db.upsertLessonSubmission(req.dbUser.id, req.params.lessonId, { answer_text: b.answer_text, assignment_status: b.assignment_status, practice_mode: b.practice_mode, group_meta: b.group_meta, status: 'in_progress' });
+      res.json({ submission });
+    } catch (e) { console.error(e); res.status(500).json({ error: 'Failed to save submission' }); }
+  });
+  router.post('/lessons/:lessonId/feedback', authenticateAcademy, aiChatLimiter, async (req, res) => {
+    const openai = createOpenRouterClient();
+    if (!openai) return res.status(503).json({ error: 'AI service not configured' });
+    try {
+      const lessonId = req.params.lessonId;
+      const assignment = await db.getAssignmentByLessonId(lessonId);
+      const submission = await db.getLessonSubmission(req.dbUser.id, lessonId);
+      const answerText = String(req.body?.answer_text || submission?.answer_text || '').trim();
+      if (!answerText) return res.status(400).json({ error: 'answer_text required' });
+      const model = pickModel(req.body?.model, req.dbUser);
+      const criteria = assignment?.rubric_json?.criteria ? assignment.rubric_json.criteria.join(', ') : 'general';
+      const graderPrompt = 'Grade assignment. JSON: score, criteria_scores, strengths, weaknesses, recommendations. Criteria: ' + criteria + '\nAnswer:\n' + answerText;
+      await assertQuota(req, estimateTokensFromText(graderPrompt));
+      let text = '', usage = null;
+      for await (const part of streamChatCompletion(openai, { model, messages: [{ role: 'system', content: 'JSON only' }, { role: 'user', content: graderPrompt }], maxTokens: 1200 })) {
+        if (part.type === 'chunk') text += part.text;
+        if (part.type === 'done') usage = part.usage;
+      }
+      let parsed;
+      try {
+        const m = text.match(/\{[\s\S]*\}/);
+        parsed = JSON.parse(m ? m[0] : text);
+      } catch {
+        parsed = { score: 6, strengths: [], weaknesses: [], recommendations: [] };
+      }
+      const row = await db.saveLessonFeedback(req.dbUser.id, lessonId, { feedbackJson: parsed, score: parsed.score, assignmentStatus: 'reviewed' });
+      await recordFeatureUsage(req, { model, promptTokens: usage?.prompt_tokens||0, completionTokens: usage?.completion_tokens||0, costUsd: estimateCostUsd(usage?.prompt_tokens||0, usage?.completion_tokens||0, model), featureMode: 'assignment_feedback' });
+      res.json({ feedback: parsed, submission: row });
+    } catch (e) { console.error(e); res.status(500).json({ error: 'Failed to generate feedback' }); }
+  });
   router.get('/knowledge-bases', authenticateAcademy, async (req, res) => {
     try {
       const bases = await db.listKnowledgeBases(req.dbUser.id);
@@ -657,7 +707,21 @@ function createRouter({ JWT_SECRET }) {
         quality_note: text.length > 500 ? 'Detailed response with good coverage.' : 'Concise response.'
       });
     }
-    res.json({ results });
+    const session = await practicum.createModelCompareSession({
+      userId: req.dbUser.id,
+      promptText,
+      models,
+      results
+    });
+    res.json({ results, session_id: session?.id || null });
+  });
+
+  router.post('/model-compare/:sessionId/choice', authenticateAcademy, async (req, res) => {
+    const chosen = String(req.body?.chosen_model || '').trim();
+    if (!chosen) return res.status(400).json({ error: 'chosen_model required' });
+    const row = await practicum.saveModelCompareChoice(req.params.sessionId, req.dbUser.id, chosen);
+    if (!row) return res.status(404).json({ error: 'session not found' });
+    res.json(row);
   });
 
   router.post('/playground', authenticateAcademy, aiChatLimiter, async (req, res) => {
@@ -1124,13 +1188,8 @@ function createRouter({ JWT_SECRET }) {
         rows = rows.slice(-MAX_CONTEXT_MESSAGES);
 
         const lessonForPrompt = lesson || (conv.lesson_id ? await db.getLessonById(conv.lesson_id) : null);
-
-        const { apiMessages, totalChars, droppedTurns } = await buildMessagesWithBudget(
-          rows,
-          lessonForPrompt,
-          req,
-          model
-        );
+        const assignmentForPrompt = lessonForPrompt ? await db.getAssignmentByLessonId(lessonForPrompt.id) : null;
+        const { apiMessages, totalChars, droppedTurns } = await buildMessagesWithBudget(rows, lessonForPrompt, req, model, assignmentForPrompt);
 
         if (personaId) {
           const persona = await practicum.getPersonaForUser(personaId, req.dbUser.id);

--- a/server.js
+++ b/server.js
@@ -1283,6 +1283,7 @@ async function startServer() {
     await upsertBuiltinPersonas();
     await upsertCourseExerciseFields();
     await seedHallucinationScenarios();
+    await seedBuiltinPromptTemplates();
     server.listen(PORT, () => {
       console.log(`Manager app server running on port ${PORT}`);
     });

--- a/services/academy/practicumStore.js
+++ b/services/academy/practicumStore.js
@@ -686,5 +686,8 @@ module.exports = {
   listHallucinationScenarios,
   createHallucinationAttempt,
   getHallucinationProgress,
-  upsertCertificate
+  upsertCertificate,
+  seedBuiltinPromptTemplates,
+  createModelCompareSession,
+  saveModelCompareChoice
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Доработка существующей AI Academy без новой архитектуры: практические задания, сохранение ответов, AI-feedback, прогресс и связанные инструменты.

## Что сделано

### Практика и уроки (P1–P5)
- Восстановлен UI в [`public/academy.html`](public/academy.html): дерево курса, панель задания, ответ, режим индивидуально/в группе
- [`public/js/academy-app.js`](public/js/academy-app.js): `renderCourseTree`, `selectLesson` с переиспользованием чата по `lesson_id`, загрузка/сохранение submission
- Seed курса **«Как с ними разговаривать»** с 3 практиками в [`database.js`](database.js)

### Ответы и AI-feedback (P2–P3)
- Расширена `academy_user_lesson_progress`: `answer_text`, `assignment_status`, `feedback_json`, `practice_mode`, `group_meta`
- API: `GET/PUT /lessons/:id/submission`, `POST /lessons/:id/feedback`
- Mentor prompt включает инструкции задания ([`prompts/mentorPrompt.js`](prompts/mentorPrompt.js))

### Прогресс (P4)
- `GET /api/academy/progress/summary` — 3/3 практики, %, last activity
- Панель `#progressSummary` в sidebar

### Инструменты (P6–P9)
- **Промпты:** RTCFSC в `/prompt-evaluate`, UI до/после, builtin templates + список
- **Модели:** `model_compare_sessions`, сохранение выбора лучшей модели, side-by-side UI
- **Галлюцинации:** интерактивный UI сценариев, улучшенный scoring по `issue_types`

## Env

См. [`.env.example`](.env.example): `DATABASE_URL`, `JWT_SECRET`, `OPENROUTER_API_KEY`.

## Как проверить

1. `npm install && npm start`
2. Войти → `/academy`
3. Слева: курс блока 1 → практика → ввести ответ → **Проверить AI** → **Выполнено**
4. Прогресс в sidebar обновляется
5. Вкладки: промпты (RTCFSC), модели (compare + выбор), тренировка (галлюцинации)

## Branch

`cursor/ai-academy-mvp-8a6c` → `master`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99e6a349-cb27-4dc9-8155-918fbbcb8a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99e6a349-cb27-4dc9-8155-918fbbcb8a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

